### PR TITLE
Extend filament's class

### DIFF
--- a/src/AdvancedWidgetConfiguration.php
+++ b/src/AdvancedWidgetConfiguration.php
@@ -1,23 +1,10 @@
 <?php
 
-namespace  EightyNine\FilamentAdvancedWidget;
+namespace EightyNine\FilamentAdvancedWidget;
 
-class AdvancedWidgetConfiguration
+use Filament\Widgets\WidgetConfiguration;
+
+class AdvancedWidgetConfiguration extends WidgetConfiguration
 {
-    /**
-     * @param  class-string<Widget>  $widget
-     * @param  array<string, mixed>  $properties
-     */
-    public function __construct(
-        readonly public string $widget,
-        protected array $properties = [],
-    ) {}
-
-    /**
-     * @return array<string, mixed>
-     */
-    public function getProperties(): array
-    {
-        return $this->properties;
-    }
+    //
 }


### PR DESCRIPTION
In order to instantiate a widget using the configuration, it has to extend filament's own class